### PR TITLE
Fix the WC admin not working

### DIFF
--- a/src/classes/class-admin.php
+++ b/src/classes/class-admin.php
@@ -201,6 +201,7 @@ namespace Niteo\WooCart\WooDash {
 					'separator36',
 					$this->admin_url . 'admin.php?page=wc-reports&tab=taxes',
 					$this->admin_url . 'admin.php?page=wc-reports',
+					'wc-admin&path=/analytics/revenue',
 					'separator37',
 					'edit.php',
 					'edit.php?post_type=page',

--- a/src/classes/class-menu.php
+++ b/src/classes/class-menu.php
@@ -30,6 +30,9 @@ namespace Niteo\WooCart\WooDash {
 
 			// users
 			'users.php',
+
+			// WC Admin
+			'wc-admin&path=/analytics/revenue',
 		];
 
 

--- a/tests/AdminTest.php
+++ b/tests/AdminTest.php
@@ -212,6 +212,7 @@ class AdminTest extends TestCase {
 				'separator36',
 				'admin.php?page=wc-reports&tab=taxes',
 				'admin.php?page=wc-reports',
+				'wc-admin&path=/analytics/revenue',
 				'separator37',
 				'edit.php',
 				'edit.php?post_type=page',


### PR DESCRIPTION
I tried to implement the other way of removing menus but did not work well. There is no way to remove the default menu items but only re-arrange them.

So, I checked the plugin code for `WooCommerce Admin` to see how the menus are implemented and added the required exception to the plugin to ignore the menu from deletion if the plugin menu is present.